### PR TITLE
Use "CTRL+C" to break into CFE instead "?"

### DIFF
--- a/cfetool.py
+++ b/cfetool.py
@@ -21,7 +21,7 @@ def skip_prompt(ser):
 def wait_prompt(ser):
 	printf("Waiting for a prompt...")
 	while True:
-		ser.write("?")
+		ser.write("\x03")
 		if(ser.read(1) == 'C' and ser.read(1) == 'F' and ser.read(1) == 'E' and ser.read(1) == '>'):
 			skip_prompt(ser)
 			printf(" OK\n")


### PR DESCRIPTION
"CTRL+C" (\x03) is a more standard and clean way to break
into the command line bootloader. Whereas "?" can work in
some routers, in others causes to bring the ? character
at the prompt, causing dm not working, because ?dm is sent
instead.

Another benefit of using CTRL+C could be to use CFE tool
without needing to break into CFE while powering up.

If CTRL+C is probed not to be effective on some routers, then
might be a good idea to use several lines, each one for sending
the keys that work on every router but ending with a carriage
return.
